### PR TITLE
BA-40 Fix favorites restaurants instant view

### DIFF
--- a/app/src/main/java/com/barapp/ui/pantallas/PantallaBaresCercanos.kt
+++ b/app/src/main/java/com/barapp/ui/pantallas/PantallaBaresCercanos.kt
@@ -28,6 +28,7 @@ import com.barapp.util.CambiarPermisosEnConfiguracion
 import com.barapp.util.Interpolator
 import com.barapp.util.Maps
 import com.barapp.util.MarkerUtils
+import com.barapp.util.RestauranteUtils.getRealIdRestaurante
 import com.barapp.util.interfaces.OnRestauranteClicked
 import com.barapp.viewModels.MainActivityViewModel
 import com.barapp.viewModels.PantallaBaresCercanosViewModel
@@ -358,7 +359,7 @@ class PantallaBaresCercanos : Fragment() {
    * @author Chort Julio
    */
   private fun eliminarFavorito(restaurante: Restaurante) {
-    restauranteFavoritoRepository.borrar(restaurante.id, mainActivityViewModel.usuario.value!!.id, mainActivityViewModel.usuario.value!!.idDetalleUsuario, object : FirestoreCallback<List<String>> {
+    restauranteFavoritoRepository.borrar(getRealIdRestaurante(restaurante), mainActivityViewModel.usuario.value!!.id, mainActivityViewModel.usuario.value!!.idDetalleUsuario, object : FirestoreCallback<List<String>> {
       override fun onSuccess(result: List<String>) {
         mainActivityViewModel.usuario.value!!.detalleUsuario!!.idsRestaurantesFavoritos = HashSet(result)
       }

--- a/app/src/main/java/com/barapp/ui/pantallas/PantallaPrincipal.kt
+++ b/app/src/main/java/com/barapp/ui/pantallas/PantallaPrincipal.kt
@@ -13,7 +13,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.barapp.R
 import com.barapp.databinding.FragmentPantallaPrincipalBinding
 import com.barapp.model.Restaurante
-import com.barapp.model.Usuario
 import com.barapp.ui.MainActivity
 import com.barapp.util.interfaces.OnRestauranteClicked
 import com.barapp.util.interfaces.OnSnackbarShowed
@@ -181,9 +180,7 @@ class PantallaPrincipal :
 
     pantallaPrincipalViewModel.listaRestaurantesDestacados.observe(viewLifecycleOwner) {
       listaRestaurante ->
-      mainActivityViewModel.usuario.observe(viewLifecycleOwner) { usuario ->
-        cargarRecyclerViewRestaurantesDestacados(listaRestaurante, usuario)
-      }
+        cargarRecyclerViewRestaurantesDestacados(listaRestaurante)
     }
 
     pantallaPrincipalViewModel.distanciasDestacados.observe(viewLifecycleOwner) {
@@ -191,16 +188,13 @@ class PantallaPrincipal :
     }
 
     pantallaPrincipalViewModel.listaRestaurantesCercaDeTi.observe(viewLifecycleOwner) {
-      listaRestaurante ->
-      mainActivityViewModel.usuario.observe(viewLifecycleOwner) { usuario ->
-        if (listaRestaurante.isEmpty()) {
+      listaRestaurante -> if (listaRestaurante.isEmpty()) {
           binding.labelCercaDeTi.visibility = View.GONE
           binding.recyclerViewHorizontalCercaDeTi.visibility = View.GONE
         } else {
-          cargarRecyclerViewCercaDeTi(listaRestaurante, usuario)
+          cargarRecyclerViewCercaDeTi(listaRestaurante)
           binding.labelCercaDeTi.visibility = View.VISIBLE
           binding.recyclerViewHorizontalCercaDeTi.visibility = View.VISIBLE
-        }
       }
     }
 
@@ -214,9 +208,9 @@ class PantallaPrincipal :
         binding.labelVistoRecientemente.visibility = View.GONE
         binding.recyclerViewHorizontalVistosRecientemente.visibility = View.GONE
       } else {
-        cargarRecyclerViewVistosRecientemente(listaRestaurante, pantallaPrincipalViewModel.usuario)
+        cargarRecyclerViewVistosRecientemente(listaRestaurante)
         binding.labelVistoRecientemente.visibility = View.VISIBLE
-        binding.labelVistoRecientemente.visibility = View.VISIBLE
+        binding.recyclerViewHorizontalVistosRecientemente.visibility = View.VISIBLE
       }
     }
 
@@ -239,34 +233,25 @@ class PantallaPrincipal :
     if (showSnackbarReservaExitosa) {
       showSnackbarReservaExitosa = false
 
-      val snackbar =
-        Snackbar.make(
-            requireView(),
-            getString(R.string.pantalla_confirmacion_reservas_snackbar_texto),
-            Snackbar.LENGTH_LONG,
-          )
-          .setDuration(Snackbar.LENGTH_LONG)
-          .show()
+      Snackbar.make(
+          requireView(),
+          getString(R.string.pantalla_confirmacion_reservas_snackbar_texto),
+          Snackbar.LENGTH_LONG,
+        )
+        .setDuration(Snackbar.LENGTH_LONG)
+        .show()
     }
   }
 
-  private fun cargarRecyclerViewRestaurantesDestacados(
-    restaurantes: List<Restaurante>,
-    usuario: Usuario,
-  ) {
-
+  private fun cargarRecyclerViewRestaurantesDestacados(restaurantes: List<Restaurante>) {
     adapterRestaurantesDestacados?.updateRestaurantesItems(restaurantes)
   }
 
-  private fun cargarRecyclerViewCercaDeTi(restaurantes: List<Restaurante>, usuario: Usuario) {
-
+  private fun cargarRecyclerViewCercaDeTi(restaurantes: List<Restaurante>) {
     cercaDeTiRecyclerAdapter?.updateRestaurantesItems(restaurantes)
   }
 
-  private fun cargarRecyclerViewVistosRecientemente(
-    restaurantes: List<Restaurante>,
-    usuario: Usuario?,
-  ) {
+  private fun cargarRecyclerViewVistosRecientemente(restaurantes: List<Restaurante>) {
     adapterVistosRecientemente?.updateRestaurantesItems(restaurantes)
   }
 
@@ -286,10 +271,10 @@ class PantallaPrincipal :
     fun onFabBuscarClicked(fabBuscar: View)
   }
 
-  override fun actualizarFavoritos() {
-    // adapterVistosRecientemente!!.notifyDataSetChanged()
-    // cercaDeTiRecyclerAdapter!!.notifyDataSetChanged()
-    // adapterRestaurantesDestacados!!.notifyDataSetChanged()
+  override fun actualizarFavoritos(holder: HorizontalRecyclerViewAdapter.RestaurantesViewHolder, idRestaurante: String) {
+    adapterRestaurantesDestacados?.addToFavorites(holder, idRestaurante)
+    cercaDeTiRecyclerAdapter?.addToFavorites(holder, idRestaurante)
+    adapterVistosRecientemente?.addToFavorites(holder, idRestaurante)
   }
 
   override fun showSnackbar(snackbar: Snackbar) {

--- a/app/src/main/java/com/barapp/ui/recyclerViewAdapters/HorizontalRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/barapp/ui/recyclerViewAdapters/HorizontalRecyclerViewAdapter.kt
@@ -20,6 +20,7 @@ import com.barapp.data.repositories.RestauranteFavoritoRepository
 import com.barapp.data.utils.FirestoreCallback
 import com.barapp.model.DetalleRestaurante
 import com.barapp.model.EstadoRestaurante
+import com.barapp.util.RestauranteUtils.getRealIdRestaurante
 import com.barapp.util.interfaces.LoadingHandler
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.MultiTransformation
@@ -126,15 +127,6 @@ class HorizontalRecyclerViewAdapter(
     holder.cardView.transitionName = idRecyclerView + restaurante.id
   }
 
-  // Si el restaurante posee idRestaurante es un RestauranteUsuario (favorito o vistoRecientemente)
-  private fun getRealIdRestaurante(restaurante: Restaurante): String {
-    return if (restaurante.idRestaurante != "") {
-      restaurante.idRestaurante
-    } else {
-      restaurante.id
-    }
-  }
-
   override fun onBindViewHolder(
     holder: RestaurantesViewHolder,
     position: Int,
@@ -198,7 +190,7 @@ class HorizontalRecyclerViewAdapter(
   }
 
   private fun eliminarFavorito(restaurante: Restaurante, holder: RestaurantesViewHolder) {
-    restauranteFavoritoRepository.borrar(restaurante.id, usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
+    restauranteFavoritoRepository.borrar(getRealIdRestaurante(restaurante), usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
       override fun onSuccess(result: List<String>) {
         usuario.detalleUsuario!!.idsRestaurantesFavoritos = HashSet(result)
         handler.actualizarFavoritos(holder, getRealIdRestaurante(restaurante))

--- a/app/src/main/java/com/barapp/ui/recyclerViewAdapters/OpinionesRecyclerAdapter.kt
+++ b/app/src/main/java/com/barapp/ui/recyclerViewAdapters/OpinionesRecyclerAdapter.kt
@@ -83,8 +83,4 @@ class OpinionesRecyclerAdapter (private val opiniones : MutableList<Opinion>) : 
             foto = binding.imageViewFotoPerfil
         }
     }
-
-    interface Callbacks {
-        fun actualizarCantidadOpiniones(opiniones: Int)
-    }
 }

--- a/app/src/main/java/com/barapp/ui/recyclerViewAdapters/ResultadosRestauranteRecyclerAdapter.kt
+++ b/app/src/main/java/com/barapp/ui/recyclerViewAdapters/ResultadosRestauranteRecyclerAdapter.kt
@@ -22,6 +22,7 @@ import com.barapp.data.repositories.DetalleUsuarioRepository
 import com.barapp.data.repositories.RestauranteFavoritoRepository
 import com.barapp.data.utils.FirestoreCallback
 import com.barapp.model.DetalleRestaurante
+import com.barapp.util.RestauranteUtils.getRealIdRestaurante
 import com.barapp.util.diffCallbacks.RestauranteDiffCallback
 import com.barapp.util.interfaces.LoadingHandler
 import com.bumptech.glide.Glide
@@ -139,7 +140,7 @@ class ResultadosRestauranteRecyclerAdapter(
   }
 
   private fun eliminarFavorito(restaurante: Restaurante, position: Int) {
-    restauranteFavoritoRepository.borrar(restaurante.id, usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
+    restauranteFavoritoRepository.borrar(getRealIdRestaurante(restaurante), usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
       override fun onSuccess(result: List<String>) {
         usuario.detalleUsuario!!.idsRestaurantesFavoritos = HashSet(result)
       }

--- a/app/src/main/java/com/barapp/util/RestauranteUtils.kt
+++ b/app/src/main/java/com/barapp/util/RestauranteUtils.kt
@@ -1,0 +1,14 @@
+package com.barapp.util
+
+import com.barapp.model.Restaurante
+
+object RestauranteUtils {
+    // Si el restaurante posee idRestaurante es un RestauranteUsuario (favorito o vistoRecientemente)
+    fun getRealIdRestaurante(restaurante: Restaurante): String {
+        return if (restaurante.idRestaurante != "") {
+            restaurante.idRestaurante
+        } else {
+            restaurante.id
+        }
+    }
+}

--- a/app/src/main/java/com/barapp/viewModels/PantallaBarViewModel.kt
+++ b/app/src/main/java/com/barapp/viewModels/PantallaBarViewModel.kt
@@ -11,6 +11,7 @@ import com.barapp.model.Restaurante
 import com.barapp.model.Usuario
 import com.barapp.data.utils.FirestoreCallback
 import com.barapp.data.repositories.RestauranteFavoritoRepository
+import com.barapp.util.RestauranteUtils.getRealIdRestaurante
 
 class PantallaBarViewModel(var restaurante: Restaurante, var usuario: Usuario) : ViewModel() {
   private val restauranteFavoritoRepository = RestauranteFavoritoRepository.instance
@@ -56,7 +57,7 @@ class PantallaBarViewModel(var restaurante: Restaurante, var usuario: Usuario) :
 
   fun eliminarFavorito() {
     this._loading.value = true
-    restauranteFavoritoRepository.borrar(restaurante.id, usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
+    restauranteFavoritoRepository.borrar(getRealIdRestaurante(restaurante), usuario.id, usuario.idDetalleUsuario, object : FirestoreCallback<List<String>> {
       override fun onSuccess(result: List<String>) {
         usuario.detalleUsuario!!.idsRestaurantesFavoritos = HashSet(result)
         _loading.postValue(false)


### PR DESCRIPTION
Ahora la actualización de los favoritos se hace al instante, no se debe recargar la página principal manualmente. A su vez se solucionó un bug de los vistos recientemente, que provocaba que el primer añadido no apareciera hasta agregar un segundo visto recientemente. Se quitó código no utilizado y/o comentado.